### PR TITLE
feat: multiplatform attestation support 

### DIFF
--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -29,6 +29,7 @@ var (
 	attestationTTLMinutes = 60
 	hostParam             = flag.String("host", "", "Host domain for TLS certificate (required)")
 	upstreamParam         = flag.String("upstream", "", "Upstream server URL (required)")
+	platformParam         = flag.String("platform", "", "Attestation platform: sev-snp or tdx (required)")
 	attestBinaryPath      string
 )
 
@@ -40,10 +41,8 @@ func init() {
 	}
 	execDir := filepath.Dir(execPath)
 
-	// Set the path to the attest binary in the same directory
-	attestBinaryPath = filepath.Join(execDir, "attest")
-
-	log.Printf("Will use attest binary at: %s", attestBinaryPath)
+	// attestBinaryPath will be set based on platform parameter
+	log.Printf("Executable directory: %s", execDir)
 }
 
 func main() {
@@ -55,6 +54,22 @@ func main() {
 	}
 	if *upstreamParam == "" {
 		log.Fatal("--upstream parameter is required")
+	}
+	if *platformParam == "" {
+		log.Fatal("--platform parameter is required (sev-snp or tdx)")
+	}
+
+	// Set attestBinaryPath based on platform
+	execPath, _ := os.Executable()
+	execDir := filepath.Dir(execPath)
+
+	switch *platformParam {
+	case "sev-snp":
+		attestBinaryPath = filepath.Join(execDir, "attest-sev-snp")
+	case "tdx":
+		attestBinaryPath = filepath.Join(execDir, "attest-tdx")
+	default:
+		log.Fatalf("Invalid platform: %s. Must be 'sev-snp' or 'tdx'", *platformParam)
 	}
 
 	log.Printf("Starting proxy with host: %s, upstream: %s", *hostParam, *upstreamParam)

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -19,7 +19,6 @@ import (
 const (
 	HTTPPort      = ":80"
 	HTTPSPort     = ":443"
-	TargetServer  = "http://127.0.0.1:8082"
 	TPMDevicePath = "/dev/tpm0"
 )
 
@@ -62,9 +61,9 @@ func main() {
 
 	generateAttestation()
 
-	target, err := url.Parse(TargetServer)
+	target, err := url.Parse(*upstreamParam)
 	if err != nil {
-		log.Fatal("Invalid target server:", err)
+		log.Fatal("Invalid upstream server:", err)
 	}
 
 	// Create reverse proxy with defaults

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -30,6 +30,7 @@ var (
 	hostParam             = flag.String("host", "", "Host domain for TLS certificate (required)")
 	upstreamParam         = flag.String("upstream", "", "Upstream server URL (required)")
 	platformParam         = flag.String("platform", "", "Attestation platform: sev-snp or tdx (required)")
+	customDataParam       = flag.String("custom-data", "", "Custom data to include in attestation (optional)")
 	attestBinaryPath      string
 )
 
@@ -65,14 +66,19 @@ func main() {
 
 	switch *platformParam {
 	case "sev-snp":
-		attestBinaryPath = filepath.Join(execDir, "attest-sev-snp")
+		// For SEV-SNP, use your Rust binary
+		attestBinaryPath = filepath.Join(execDir, "attest_amd")
 	case "tdx":
-		attestBinaryPath = filepath.Join(execDir, "attest")
+		// Keep existing TDX binary
+		attestBinaryPath = filepath.Join(execDir, "attest_tdx")
 	default:
 		log.Fatalf("Invalid platform: %s. Must be 'sev-snp' or 'tdx'", *platformParam)
 	}
 
-	log.Printf("Starting proxy with host: %s, upstream: %s", *hostParam, *upstreamParam)
+	log.Printf("Starting proxy with host: %s, upstream: %s, platform: %s", *hostParam, *upstreamParam, *platformParam)
+	if *customDataParam != "" {
+		log.Printf("Using custom data: %s", *customDataParam)
+	}
 
 	generateAttestation()
 
@@ -167,8 +173,23 @@ func getClientIP(req *http.Request) string {
 }
 
 func generateAttestation() {
-	// Execute the attest command from the same directory as this executable
-	cmd := exec.Command(attestBinaryPath, "--format", "compressed")
+	var cmd *exec.Cmd
+
+	switch *platformParam {
+	case "sev-snp":
+		if *customDataParam != "" {
+			cmd = exec.Command(attestBinaryPath, "attest", *customDataParam)
+		} else {
+			cmd = exec.Command(attestBinaryPath, "attest")
+		}
+	case "tdx":
+		cmd = exec.Command(attestBinaryPath, "--format", "compressed")
+	default:
+		log.Fatalf("Invalid platform: %s", *platformParam)
+	}
+
+	log.Printf("Executing attestation command: %s with args: %v", attestBinaryPath, cmd.Args[1:])
+
 	output, err := cmd.Output()
 	if err != nil {
 		log.Fatalf("Failed to execute attest command at %s: %v", attestBinaryPath, err)
@@ -177,9 +198,12 @@ func generateAttestation() {
 	// The output is already base64 encoded, just clean it up
 	cachedAttestationB64 = strings.TrimSpace(string(output))
 
-	// Print the attestation for debugging
-	log.Printf("Generated attestation: %s...",
-		cachedAttestationB64)
+	// Print the attestation for debugging (truncated for security)
+	if len(cachedAttestationB64) > 50 {
+		log.Printf("Generated attestation (%s): %s...", *platformParam, cachedAttestationB64[:50])
+	} else {
+		log.Printf("Generated attestation (%s): %s", *platformParam, cachedAttestationB64)
+	}
 
 	lastAttestationTime = time.Now()
 }

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -198,12 +198,7 @@ func generateAttestation() {
 	// The output is already base64 encoded, just clean it up
 	cachedAttestationB64 = strings.TrimSpace(string(output))
 
-	// Print the attestation for debugging (truncated for security)
-	if len(cachedAttestationB64) > 50 {
-		log.Printf("Generated attestation (%s): %s...", *platformParam, cachedAttestationB64[:50])
-	} else {
-		log.Printf("Generated attestation (%s): %s", *platformParam, cachedAttestationB64)
-	}
+	log.Printf("Generated attestation (%s): %s", *platformParam, cachedAttestationB64)
 
 	lastAttestationTime = time.Now()
 }

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -67,7 +67,7 @@ func main() {
 	case "sev-snp":
 		attestBinaryPath = filepath.Join(execDir, "attest-sev-snp")
 	case "tdx":
-		attestBinaryPath = filepath.Join(execDir, "attest-tdx")
+		attestBinaryPath = filepath.Join(execDir, "attest")
 	default:
 		log.Fatalf("Invalid platform: %s. Must be 'sev-snp' or 'tdx'", *platformParam)
 	}
@@ -98,6 +98,11 @@ func main() {
 	// Add attestation to response
 	proxy.ModifyResponse = func(resp *http.Response) error {
 		resp.Header.Set("Attestation-Report", cachedAttestationB64)
+
+		// Add CORS headers to expose the custom header
+		resp.Header.Set("Access-Control-Allow-Origin", "*")
+		resp.Header.Set("Access-Control-Expose-Headers", "Attestation-Report")
+
 		return nil
 	}
 


### PR DESCRIPTION
# Add Multi-Platform Attestation Support

## Summary
Adds support for both TDX and SEV-SNP attestation platforms with configurable parameters. Replaces hardcoded values with command-line flags for flexible deployment.

## Changes
- **Multi-Platform Support**: Added `--platform` flag to support both `sev-snp` and `tdx` attestation
- **Configurable Parameters**: Added `--host`, `--upstream`, and `--custom-data` flags
- **Dynamic Binary Selection**: Automatically selects `attest_amd` or `attest_tdx` based on platform
- **Enhanced CORS**: Added proper CORS headers to expose attestation headers
- **Improved Logging**: Better visibility into attestation generation and execution

## Command Line Flags
```bash
--host          Host domain for TLS certificate (required)
--upstream      Upstream server URL (required) 
--platform      Attestation platform: sev-snp or tdx (required)
--custom-data   Custom data to include in attestation (optional)
```

## Usage Examples
```bash
# SEV-SNP attestation
./proxy --host=example.com --upstream=http://localhost:8080 --platform=sev-snp

# TDX attestation with custom data
./proxy --host=example.com --upstream=http://localhost:8080 --platform=tdx --custom-data="nonce-123"
```

## Key Changes
- **Binary Path Resolution**: Dynamically sets attestation binary based on platform parameter
- **Command Execution**: Platform-specific command construction for attestation generation
- **Error Handling**: Improved error messages with binary path information
- **Response Headers**: Added `Access-Control-Expose-Headers` for web compatibility

## Platform Support
- **SEV-SNP**: Uses `attest_amd` binary with optional custom data parameter
- **TDX**: Uses `attest_tdx` binary with compressed format flag
- **Validation**: Ensures platform parameter is valid during startup

## Backward Compatibility
Breaking changes due to required command-line parameters. Previous hardcoded configurations must be migrated to use new flags.